### PR TITLE
`Method`s and `ContentType`s exposed.

### DIFF
--- a/src/main/groovy/org/jenkinsci/plugins/buildflow/http/extension/HttpBuildFlowDSL.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/buildflow/http/extension/HttpBuildFlowDSL.groovy
@@ -3,7 +3,18 @@ package org.jenkinsci.plugins.buildflow.http.extension
 import com.cloudbees.plugins.flow.FlowDelegate
 import groovyx.net.http.HTTPBuilder
 import static groovyx.net.http.Method.GET
+import static groovyx.net.http.Method.PUT
+import static groovyx.net.http.Method.POST
+import static groovyx.net.http.Method.DELETE
+import static groovyx.net.http.Method.HEAD
+import static groovyx.net.http.Method.PATCH
+import static groovyx.net.http.ContentType.ANY
 import static groovyx.net.http.ContentType.TEXT
+import static groovyx.net.http.ContentType.JSON
+import static groovyx.net.http.ContentType.XML
+import static groovyx.net.http.ContentType.HTML
+import static groovyx.net.http.ContentType.URLENC
+import static groovyx.net.http.ContentType.BINARY
 
 /**
  * Created by jniesen on 5/5/14.
@@ -11,6 +22,25 @@ import static groovyx.net.http.ContentType.TEXT
 class HttpBuildFlowDSL {
   FlowDelegate flowDelegate
   HTTPBuilder http
+
+  class Method {
+    final static GET = groovyx.net.http.Method.GET
+    final static PUT = groovyx.net.http.Method.PUT
+    final static POST = groovyx.net.http.Method.POST
+    final static DELETE = groovyx.net.http.Method.DELETE
+    final static HEAD = groovyx.net.http.Method.HEAD
+    final static PATCH = groovyx.net.http.Method.PATCH
+  }
+
+  class ContentType {
+    final static ANY = groovyx.net.http.ContentType.ANY
+    final static TEXT = groovyx.net.http.ContentType.TEXT
+    final static JSON = groovyx.net.http.ContentType.JSON
+    final static XML = groovyx.net.http.ContentType.XML
+    final static HTML = groovyx.net.http.ContentType.HTML
+    final static URLENC = groovyx.net.http.ContentType.URLENC
+    final static BINARY = groovyx.net.http.ContentType.BINARY
+  }
 
   def HttpBuildFlowDSL(FlowDelegate flowDelegate, HTTPBuilder httpBuilder) {
     this.flowDelegate = flowDelegate


### PR DESCRIPTION
`Method`s and `ContentType`s exposed so users of the extension can do more than just `get`s with `ContentType.TEXT`.
