### PR TITLE
Preparing for v0.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
 language: java
+script: mvn test findbugs:check -B

--- a/src/findbugs/excludesFilter.xml
+++ b/src/findbugs/excludesFilter.xml
@@ -1,0 +1,8 @@
+<FindBugsFilter>
+  <Match>
+    <Source name="~.*\.groovy" />
+    <And>
+      <Bug pattern="SE_NO_SERIALVERSIONID" />
+    </And>
+  </Match>
+</FindBugsFilter>

--- a/src/main/java/org/jenkinsci/plugins/buildflow/http/extension/HttpBuildFlowDSLExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/buildflow/http/extension/HttpBuildFlowDSLExtension.java
@@ -16,7 +16,7 @@ public class HttpBuildFlowDSLExtension extends BuildFlowDSLExtension {
 
     @Override
     public Object createExtension(String extensionName, FlowDelegate flowDelegate) {
-      if (extensionName == this.EXTENSION_NAME) {
+      if (extensionName.equals(this.EXTENSION_NAME)) {
         return getHttpBuildFlowDSL(flowDelegate);
       }
 

--- a/src/main/java/org/jenkinsci/plugins/buildflow/http/extension/PreemptiveHttpClient.java
+++ b/src/main/java/org/jenkinsci/plugins/buildflow/http/extension/PreemptiveHttpClient.java
@@ -51,9 +51,14 @@ public class PreemptiveHttpClient {
         if (is != null) {
             try {
                 properties.load(is);
-                is.close();
             } catch (IOException e) {
                 // ignore, use the default value
+            } finally {
+                try {
+                    is.close();
+                } catch (IOException e) {
+                  // ignore
+                }
             }
         }
         CLIENT_VERSION = properties.getProperty("client.version", "unknown");


### PR DESCRIPTION
Preparing for the next release.

Since the last release it appears that Findbugs has now been included somewhere in the dependency tree for building Jenkins plugins. This became apparent when findbugs started throwing errors while doing a ``mvn clean install``.

Findbugs checks that failed:

- ``SE_NO_SERIALVERSIONID``: addressed by adding a filter on groovy files.
- ``ES_COMPARING_PARAMETER_STRING_WITH_EQ``: addressed by modifying code.
- ``OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE`` addressed by modifying code.

I've also added the findbugs check to the build stage in Travis so it will be enforced in PRs.

