### PR TITLE
Fix NPE when retrieving empty body

### DIFF
--- a/src/main/groovy/org/jenkinsci/plugins/buildflow/http/extension/HttpBuildFlowDSL.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/buildflow/http/extension/HttpBuildFlowDSL.groovy
@@ -64,7 +64,7 @@ class HttpBuildFlowDSL {
     this.http.request(url, GET, TEXT) { req ->
       headers.Accept = "application/json"
       response.success = { resp, reader ->
-        return reader.text
+        return reader?.text
       }
     }
   }


### PR DESCRIPTION
Fixes #2 

I had the same problem as reported and this prevents the NPE, though you still have to check that the response returned isn't null in the build flow.